### PR TITLE
Fix gameday weather NWS API fallback logic

### DIFF
--- a/src/main/kotlin/org/j3y/HuskerBot2/service/WeatherService.kt
+++ b/src/main/kotlin/org/j3y/HuskerBot2/service/WeatherService.kt
@@ -51,13 +51,16 @@ class WeatherService(
             val hoursUntilGame = ChronoUnit.HOURS.between(now, targetDate)
             val daysUntilGame = ChronoUnit.DAYS.between(now, targetDate)
             
-            // Use Tomorrow Weather API if within 5 days (120 hours), otherwise fallback to NWS
-            return if (daysUntilGame <= 5) {
-                log.info("Using Tomorrow Weather API for forecast $daysUntilGame days out")
+            // Use Tomorrow Weather API if within 120 hours, otherwise fallback to NWS
+            return if (hoursUntilGame <= 120) {
+                log.info("Using Tomorrow Weather API for forecast $hoursUntilGame hours out")
                 getTomorrowWeatherForecast(latitude, longitude, targetDate, hoursUntilGame)
-            } else {
-                log.info("Using NWS API for forecast $daysUntilGame days out (beyond Tomorrow Weather 5-day limit)")
+            } else if (daysUntilGame <= 7) {
+                log.info("Using NWS API for forecast $daysUntilGame days out (beyond Tomorrow Weather 120-hour limit)")
                 getNWSWeatherForecast(latitude, longitude, targetDate)
+            } else {
+                log.warn("Game is $daysUntilGame days out - beyond reliable weather forecast range (7 days)")
+                null
             }
         } catch (e: Exception) {
             log.error("Error getting weather forecast for $latitude, $longitude", e)


### PR DESCRIPTION
## Summary

- Fix NWS API fallback for games more than 5 days out that was previously blocked by hard 14-day limit
- Improve API selection logic to use 120-hour threshold instead of day-based calculation for better precision
- Add proper error handling when weather data is unavailable

## Changes

- Remove 14-day hard limit in GamedayWeather command that prevented NWS fallback
- Update WeatherService to use hours-based threshold (120 hours) for Tomorrow.io API selection
- Add null check for weather data with user-friendly error message
- Update footer text to reflect new API usage ranges
- Ensure games beyond 5 days properly fall back to NWS API (within 7-day forecast limit)

This resolves issues where the gameday weather command would fail for games 5+ days out instead of falling back to the NWS API as intended.