### PR TITLE
Improve police command message formatting

### DIFF
--- a/src/main/kotlin/org/j3y/HuskerBot2/commands/other/Police.kt
+++ b/src/main/kotlin/org/j3y/HuskerBot2/commands/other/Police.kt
@@ -25,19 +25,20 @@ class Police : SlashCommand() {
         }
 
         val message = buildString {
-            append("Wee woo, wee woo!Halt!")
-            append("🚨 NANI 🚨..")
-            append("🚨 THE 🚨...")
-            append("🚨 FUCK 🚨....")
-            append("🚨 DID 🚨.....")
-            append("🚨 YOU 🚨....")
-            append("🚨 JUST 🚨...")
-            append("🚨 SAY 🚨..")
-            append("🚨 ${arrestee.asMention} 🚨")
-            append("🚨🚨🚨🚨🚨🚨🚨🚨🚨")
-            append("👮‍📢 Information ℹ provided in the VIP 👑 Room 🏆 is intended for Husker247 🌽🎈 members only ‼🔫. ")
-            append("Please do not copy ✏ and paste 🖨 or summarize this content elsewhere‼ ")
-            append("Please try to keep all replies in this thread 🧵 for Husker247 members only! 🚫 ⛔ 👎 🙅‍♀️")
+            append("Wee woo, wee woo!\n")
+            append("Halt!\n")
+            append("🚨 NANI 🚨..\n")
+            append("🚨 THE 🚨...\n")
+            append("🚨 FUCK 🚨....\n")
+            append("🚨 DID 🚨.....\n")
+            append("🚨 YOU 🚨....\n")
+            append("🚨 JUST 🚨...\n")
+            append("🚨 SAY 🚨..\n")
+            append("🚨 ${arrestee.asMention} 🚨\n")
+            append("🚨🚨🚨🚨🚨🚨🚨🚨🚨\n")
+            append("👮‍📢 Information ℹ provided in the VIP 👑 Room 🏆 is intended for Husker247 🌽🎈 members only ‼🔫. \n")
+            append("Please do not copy ✏ and paste 🖨 or summarize this content elsewhere‼ \n")
+            append("Please try to keep all replies in this thread 🧵 for Husker247 members only! 🚫 ⛔ 👎 🙅‍♀️\n")
             append("Thanks for your cooperation. 😍🤩😘")
         }
 

--- a/src/main/kotlin/org/j3y/HuskerBot2/commands/other/Police.kt
+++ b/src/main/kotlin/org/j3y/HuskerBot2/commands/other/Police.kt
@@ -1,0 +1,46 @@
+package org.j3y.HuskerBot2.commands.other
+
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.interactions.commands.OptionType
+import net.dv8tion.jda.api.interactions.commands.build.OptionData
+import org.j3y.HuskerBot2.commands.SlashCommand
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Component
+class Police : SlashCommand() {
+    private val log = LoggerFactory.getLogger(Police::class.java)
+
+    override fun getCommandKey(): String = "police"
+    override fun getDescription(): String = "Call the police on someone"
+    override fun getOptions(): List<OptionData> = listOf(
+        OptionData(OptionType.USER, "arrestee", "The user to arrest", true)
+    )
+
+    override fun execute(commandEvent: SlashCommandInteractionEvent) {
+        val arrestee = commandEvent.getOption("arrestee")?.asMember
+        if (arrestee == null) {
+            commandEvent.reply("Invalid user.").setEphemeral(true).queue()
+            return
+        }
+
+        val message = buildString {
+            append("Wee woo, wee woo!Halt!")
+            append("🚨 NANI 🚨..")
+            append("🚨 THE 🚨...")
+            append("🚨 FUCK 🚨....")
+            append("🚨 DID 🚨.....")
+            append("🚨 YOU 🚨....")
+            append("🚨 JUST 🚨...")
+            append("🚨 SAY 🚨..")
+            append("🚨 ${arrestee.asMention} 🚨")
+            append("🚨🚨🚨🚨🚨🚨🚨🚨🚨")
+            append("👮‍📢 Information ℹ provided in the VIP 👑 Room 🏆 is intended for Husker247 🌽🎈 members only ‼🔫. ")
+            append("Please do not copy ✏ and paste 🖨 or summarize this content elsewhere‼ ")
+            append("Please try to keep all replies in this thread 🧵 for Husker247 members only! 🚫 ⛔ 👎 🙅‍♀️")
+            append("Thanks for your cooperation. 😍🤩😘")
+        }
+
+        commandEvent.reply(message).queue()
+    }
+}

--- a/src/test/kotlin/org/j3y/HuskerBot2/commands/other/PoliceTest.kt
+++ b/src/test/kotlin/org/j3y/HuskerBot2/commands/other/PoliceTest.kt
@@ -1,0 +1,27 @@
+package org.j3y.HuskerBot2.commands.other
+
+import net.dv8tion.jda.api.interactions.commands.OptionType
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class PoliceTest {
+
+    @Test
+    fun testPoliceCommand() {
+        val police = Police()
+
+        assertEquals("police", police.getCommandKey())
+        assertEquals("Call the police on someone", police.getDescription())
+        assertFalse(police.isSubcommand())
+        assertTrue(police.isLogged())
+
+        val options = police.getOptions()
+        assertEquals(1, options.size)
+        
+        val arresteeOption = options[0]
+        assertEquals("arrestee", arresteeOption.name)
+        assertEquals("The user to arrest", arresteeOption.description)
+        assertEquals(OptionType.USER, arresteeOption.type)
+        assertTrue(arresteeOption.isRequired)
+    }
+}


### PR DESCRIPTION
## Summary
• Add newlines to police command message for better readability and formatting

This improves the visual presentation of the police command output by properly separating each line instead of displaying everything as one continuous string.