### PR TITLE
Fix volleyball schedule lookup

### DIFF
--- a/src/main/kotlin/org/j3y/HuskerBot2/commands/schedules/VbSched.kt
+++ b/src/main/kotlin/org/j3y/HuskerBot2/commands/schedules/VbSched.kt
@@ -20,8 +20,6 @@ class VbSched : SlashCommand() {
     @Autowired
     lateinit var huskersDotComService: HuskersDotComService
 
-    private val volleyballScheduleId = 1363
-
     override fun getCommandKey(): String = "vb"
     override fun getDescription(): String = "Get the Nebraska volleyball schedule"
     override fun isSubcommand(): Boolean = true
@@ -32,7 +30,7 @@ class VbSched : SlashCommand() {
         commandEvent.deferReply().queue()
 
         try {
-            val apiJson: JsonNode = huskersDotComService.getScheduleById(volleyballScheduleId)
+            val apiJson: JsonNode = huskersDotComService.getVolleyballSchedule()
             val events = apiJson.path("data")
 
             if (events.isEmpty) {

--- a/src/main/kotlin/org/j3y/HuskerBot2/service/DefaultHuskersDotComService.kt
+++ b/src/main/kotlin/org/j3y/HuskerBot2/service/DefaultHuskersDotComService.kt
@@ -16,6 +16,7 @@ class DefaultHuskersDotComService : HuskersDotComService {
         2028 to 244
     )
     val url: String = "https://huskers.com/website-api/schedule-events?filter[schedule_id]={schedId}&filter[hide_from_specific_sport_schedule]=false&include=conference.image,opponent.customLogo,opponent.officialLogo,opponentLogo,postEventArticle.image,preEventArticle.image,presentedBy,promotionalItems.image,schedule.sport,scheduleEventLinks.icon,scheduleEventResult,secondOpponent.customLogo,secondOpponent.officialLogo,secondOpponentLogo,tournament&per_page=100&sort=datetime&page=1"
+    val sportsUrl: String = "https://huskers.com/website-api/sports?per_page=100"
 
     val client = RestTemplate()
 
@@ -33,5 +34,20 @@ class DefaultHuskersDotComService : HuskersDotComService {
         val uri = UriComponentsBuilder.fromUriString(url).buildAndExpand(scheduleId)
 
         return client.getForObject(uri.toUriString(), JsonNode::class.java) ?: throw RuntimeException("Unable to retrieve schedule for id $scheduleId")
+    }
+
+    override fun getVolleyballSchedule(): JsonNode {
+        val sports = client.getForObject(sportsUrl, JsonNode::class.java)
+            ?: throw RuntimeException("Unable to retrieve sports list")
+        val volleyball = sports.path("data").firstOrNull { sport ->
+            sport.path("slug").asText() == "volleyball" &&
+                (sport.path("active").isMissingNode || sport.path("active").asBoolean(false))
+        } ?: throw RuntimeException("Unable to find active volleyball sport")
+
+        val scheduleId = volleyball.path("schedule_id").takeIf { it.isIntegralNumber }
+            ?.asInt()?.takeIf { it > 0 }
+            ?: throw RuntimeException("Active volleyball sport has no valid schedule_id")
+
+        return getScheduleById(scheduleId)
     }
 }

--- a/src/main/kotlin/org/j3y/HuskerBot2/service/HuskersDotComService.kt
+++ b/src/main/kotlin/org/j3y/HuskerBot2/service/HuskersDotComService.kt
@@ -6,4 +6,5 @@ import net.dv8tion.jda.api.entities.MessageEmbed
 interface HuskersDotComService {
     fun getSchedule(year: Int): JsonNode
     fun getScheduleById(scheduleId: Int): JsonNode
+    fun getVolleyballSchedule(): JsonNode
 }

--- a/src/test/kotlin/org/j3y/HuskerBot2/commands/schedules/VbSchedTest.kt
+++ b/src/test/kotlin/org/j3y/HuskerBot2/commands/schedules/VbSchedTest.kt
@@ -54,7 +54,7 @@ class VbSchedTest {
         val emptyData = Mockito.mock(JsonNode::class.java)
         `when`(emptyData.isEmpty).thenReturn(true)
         `when`(apiJson.path("data")).thenReturn(emptyData)
-        `when`(service.getScheduleById(1363)).thenReturn(apiJson)
+        `when`(service.getVolleyballSchedule()).thenReturn(apiJson)
 
         cmd.execute(event)
 
@@ -108,13 +108,13 @@ class VbSchedTest {
         dataArray.add(game1)
         apiJson.set("data", dataArray)
 
-        `when`(service.getScheduleById(1363)).thenReturn(apiJson)
+        `when`(service.getVolleyballSchedule()).thenReturn(apiJson)
 
         cmd.execute(event)
 
         // verify deferReply and service call
         Mockito.verify(replyAction).queue()
-        Mockito.verify(service).getScheduleById(1363)
+        Mockito.verify(service).getVolleyballSchedule()
         
         // verify a message was sent
         Mockito.verify(hook).sendMessage(Mockito.anyString())
@@ -132,7 +132,7 @@ class VbSchedTest {
         val msgAction = Mockito.mock(WebhookMessageCreateAction::class.java) as WebhookMessageCreateAction<Message>
         `when`(hook.sendMessage(Mockito.anyString())).thenReturn(msgAction)
 
-        `when`(service.getScheduleById(1363)).thenThrow(RuntimeException("API Error"))
+        `when`(service.getVolleyballSchedule()).thenThrow(RuntimeException("API Error"))
 
         cmd.execute(event)
 
@@ -187,13 +187,13 @@ class VbSchedTest {
         dataArray.add(game1)
         apiJson.set("data", dataArray)
 
-        `when`(service.getScheduleById(1363)).thenReturn(apiJson)
+        `when`(service.getVolleyballSchedule()).thenReturn(apiJson)
 
         cmd.execute(event)
 
         // Verify the execution completed without errors
         Mockito.verify(replyAction).queue()
-        Mockito.verify(service).getScheduleById(1363)
+        Mockito.verify(service).getVolleyballSchedule()
         Mockito.verify(hook).sendMessage(Mockito.anyString())
         Mockito.verify(msgAction).queue()
     }
@@ -241,13 +241,13 @@ class VbSchedTest {
         dataArray.add(game1)
         apiJson.set("data", dataArray)
 
-        `when`(service.getScheduleById(1363)).thenReturn(apiJson)
+        `when`(service.getVolleyballSchedule()).thenReturn(apiJson)
 
         cmd.execute(event)
 
         // Verify the execution completed without errors
         Mockito.verify(replyAction).queue()
-        Mockito.verify(service).getScheduleById(1363)
+        Mockito.verify(service).getVolleyballSchedule()
         Mockito.verify(hook).sendMessage(Mockito.anyString())
         Mockito.verify(msgAction).queue()
     }
@@ -295,13 +295,13 @@ class VbSchedTest {
         dataArray.add(game1)
         apiJson.set("data", dataArray)
 
-        `when`(service.getScheduleById(1363)).thenReturn(apiJson)
+        `when`(service.getVolleyballSchedule()).thenReturn(apiJson)
 
         cmd.execute(event)
 
         // Verify the execution completed without errors
         Mockito.verify(replyAction).queue()
-        Mockito.verify(service).getScheduleById(1363)
+        Mockito.verify(service).getVolleyballSchedule()
         Mockito.verify(hook).sendMessage(Mockito.anyString())
         Mockito.verify(msgAction).queue()
     }
@@ -349,13 +349,13 @@ class VbSchedTest {
         dataArray.add(game1)
         apiJson.set("data", dataArray)
 
-        `when`(service.getScheduleById(1363)).thenReturn(apiJson)
+        `when`(service.getVolleyballSchedule()).thenReturn(apiJson)
 
         cmd.execute(event)
 
         // Verify the execution completed without errors
         Mockito.verify(replyAction).queue()
-        Mockito.verify(service).getScheduleById(1363)
+        Mockito.verify(service).getVolleyballSchedule()
         Mockito.verify(hook).sendMessage(Mockito.anyString())
         Mockito.verify(msgAction).queue()
     }
@@ -403,13 +403,13 @@ class VbSchedTest {
         dataArray.add(game1)
         apiJson.set("data", dataArray)
 
-        `when`(service.getScheduleById(1363)).thenReturn(apiJson)
+        `when`(service.getVolleyballSchedule()).thenReturn(apiJson)
 
         cmd.execute(event)
 
         // Verify the execution completed without errors
         Mockito.verify(replyAction).queue()
-        Mockito.verify(service).getScheduleById(1363)
+        Mockito.verify(service).getVolleyballSchedule()
         Mockito.verify(hook).sendMessage(Mockito.anyString())
         Mockito.verify(msgAction).queue()
     }
@@ -457,13 +457,13 @@ class VbSchedTest {
         dataArray.add(game1)
         apiJson.set("data", dataArray)
 
-        `when`(service.getScheduleById(1363)).thenReturn(apiJson)
+        `when`(service.getVolleyballSchedule()).thenReturn(apiJson)
 
         cmd.execute(event)
 
         // Verify the execution completed without errors
         Mockito.verify(replyAction).queue()
-        Mockito.verify(service).getScheduleById(1363)
+        Mockito.verify(service).getVolleyballSchedule()
         Mockito.verify(hook).sendMessage(Mockito.anyString())
         Mockito.verify(msgAction).queue()
     }
@@ -511,13 +511,13 @@ class VbSchedTest {
         dataArray.add(game1)
         apiJson.set("data", dataArray)
 
-        `when`(service.getScheduleById(1363)).thenReturn(apiJson)
+        `when`(service.getVolleyballSchedule()).thenReturn(apiJson)
 
         cmd.execute(event)
 
         // Verify the execution completed without errors
         Mockito.verify(replyAction).queue()
-        Mockito.verify(service).getScheduleById(1363)
+        Mockito.verify(service).getVolleyballSchedule()
         Mockito.verify(hook).sendMessage(Mockito.anyString())
         Mockito.verify(msgAction).queue()
     }
@@ -565,13 +565,13 @@ class VbSchedTest {
         dataArray.add(game1)
         apiJson.set("data", dataArray)
 
-        `when`(service.getScheduleById(1363)).thenReturn(apiJson)
+        `when`(service.getVolleyballSchedule()).thenReturn(apiJson)
 
         cmd.execute(event)
 
         // Verify the execution completed without errors
         Mockito.verify(replyAction).queue()
-        Mockito.verify(service).getScheduleById(1363)
+        Mockito.verify(service).getVolleyballSchedule()
         Mockito.verify(hook).sendMessage(Mockito.anyString())
         Mockito.verify(msgAction).queue()
     }
@@ -633,7 +633,7 @@ class VbSchedTest {
         dataArray.add(nonNebraskaGame)
         apiJson.set("data", dataArray)
 
-        `when`(service.getScheduleById(1363)).thenReturn(apiJson)
+        `when`(service.getVolleyballSchedule()).thenReturn(apiJson)
 
         cmd.execute(event)
 
@@ -647,7 +647,7 @@ class VbSchedTest {
         
         // Verify the execution completed without errors
         Mockito.verify(replyAction).queue()
-        Mockito.verify(service).getScheduleById(1363)
+        Mockito.verify(service).getVolleyballSchedule()
         Mockito.verify(msgAction).queue()
     }
 

--- a/src/test/kotlin/org/j3y/HuskerBot2/service/DefaultHuskersDotComServiceTest.kt
+++ b/src/test/kotlin/org/j3y/HuskerBot2/service/DefaultHuskersDotComServiceTest.kt
@@ -86,4 +86,38 @@ class DefaultHuskersDotComServiceTest {
             assertTrue(ex.message!!.contains("Unable to retrieve schedule for year 2026"))
         }
     }
+
+    @Test
+    fun `getVolleyballSchedule finds active volleyball schedule and retrieves events`() {
+        val sports = mapper.readTree("""{"data":[{"slug":"football","active":true,"schedule_id":1},{"slug":"volleyball","active":true,"schedule_id":1363}]}""")
+        val schedule = mapper.readTree("""{"data":[{"id":1}]}""")
+
+        Mockito.mockConstruction(RestTemplate::class.java) { mock, _ ->
+            `when`(mock.getForObject(ArgumentMatchers.anyString(), ArgumentMatchers.eq(JsonNode::class.java)))
+                .thenReturn(sports, schedule)
+        }.use { construction ->
+            val result = DefaultHuskersDotComService().getVolleyballSchedule()
+
+            assertEquals(schedule, result)
+            val mockRt = construction.constructed()[0]
+            val urls = ArgumentCaptor.forClass(String::class.java)
+            Mockito.verify(mockRt, Mockito.times(2)).getForObject(urls.capture(), ArgumentMatchers.eq(JsonNode::class.java))
+            assertEquals("https://huskers.com/website-api/sports?per_page=100", urls.allValues[0])
+            assertTrue(urls.allValues[1].contains("filter[schedule_id]=1363"))
+        }
+    }
+
+    @Test
+    fun `getVolleyballSchedule fails when active volleyball schedule id is missing`() {
+        val sports = mapper.readTree("""{"data":[{"slug":"volleyball","active":true}]}""")
+
+        Mockito.mockConstruction(RestTemplate::class.java) { mock, _ ->
+            `when`(mock.getForObject(ArgumentMatchers.anyString(), ArgumentMatchers.eq(JsonNode::class.java))).thenReturn(sports)
+        }.use {
+            val ex = assertThrows(RuntimeException::class.java) {
+                DefaultHuskersDotComService().getVolleyballSchedule()
+            }
+            assertTrue(ex.message!!.contains("valid schedule_id"))
+        }
+    }
 }


### PR DESCRIPTION
Loads the active Volleyball schedule ID from Huskers.com before requesting events, so /schedule vb no longer relies on a stale hardcoded ID.\n\nTests: ./gradlew test --tests 'org.j3y.HuskerBot2.commands.schedules.VbSchedTest' --tests 'org.j3y.HuskerBot2.service.DefaultHuskersDotComServiceTest'